### PR TITLE
[FXC-8846] ESP129: guard BRepClass3d::OuterShell against invalid BREP-with-voids crash

### DIFF
--- a/download.sh
+++ b/download.sh
@@ -31,7 +31,8 @@ if [ "$version" = "128" ]; then
   cp replace128evaluate.c ESP/EngSketchPad/src/EGADS/util/evaluate.c
 fi
 if [ "$version" = "129" ]; then
-  echo "Patching ESP129: EGADS try/catch for OCC calls (FXC-6881), null surface checks"
+  echo "Patching ESP129: EGADS try/catch for OCC calls (FXC-6881), null surface checks, OuterShell guard (FXC-8846)"
   patch -p0 < egadsTopo129.patch
   patch -p0 < egadsIO129.patch
+  patch -p0 < egadsTopoOuterShell129.patch
 fi

--- a/egadsTopoOuterShell129.patch
+++ b/egadsTopoOuterShell129.patch
@@ -1,0 +1,42 @@
+--- ESP/EngSketchPad/src/EGADS/src/egadsTopo.cpp	2026-06-09 12:09:12.000000000 +0000
++++ ESP/EngSketchPad/src/EGADS/src/egadsTopo.cpp	2026-06-09 12:09:29.000000000 +0000
+@@ -2062,7 +2062,38 @@
+     TopoDS_Shell oShell;
+     if (solid == 1) {
+       TopoDS_Solid Solid = TopoDS::Solid(body->shape);
+-      oShell = BRepClass3d::OuterShell(Solid);
++      try {
++        oShell = BRepClass3d::OuterShell(Solid);
++      }
++      catch (...) {
++        printf(" EGADS Warning: Body %2d -> OuterShell Error (nShell = %d)!\n",
++               i+1, nShell);
++        /* use biggest bounding box */
++        if (nShell == 1) {
++          shape  = body->shells.map(1);
++          oShell = TopoDS::Shell(shape);
++        } else {
++          double BoxSize = 0.0;
++          for (j = 0; j < nShell; j++) {
++            double       bbox[6];
++            Bnd_Box      Box;
++            shape              = body->shells.map(j+1);
++            TopoDS_Shell Shell = TopoDS::Shell(shape);
++#if CASVER >= 730
++            BRepBndLib::AddOptimal(Shell, Box, Standard_False);
++#else
++            BRepBndLib::Add(Shell, Box);
++#endif
++            Box.Get(bbox[0], bbox[1], bbox[2], bbox[3], bbox[4], bbox[5]);
++            double bSize = sqrt((bbox[3]-bbox[0])*(bbox[3]-bbox[0]) +
++                                (bbox[4]-bbox[1])*(bbox[4]-bbox[1]) +
++                                (bbox[5]-bbox[2])*(bbox[5]-bbox[2]));
++            if (bSize <= BoxSize) continue;
++            BoxSize = bSize;
++            oShell  = Shell;
++          }
++        }
++      }
+       body->senses = new int[nShell];
+     }
+ 


### PR DESCRIPTION
## Summary

A customer STEP model (Scania-Engine-V8-XT-Turbo) passes OpenCASCADE's STEP reader but **crashes EGADS during `EG_loadModel`**, before the new GAI tessellator ever runs. The crash is an OpenCASCADE `Standard_DomainError` (`Geom_BSplineCurve::Segment`, inverted parameter range) thrown from `BRepClass3d::OuterShell(Solid)` during EGADS's outer-shell solid classification (`EG_traverseBody`), triggered on invalid breps-with-voids. (The model has exactly two such bodies, #2951 and #2953; dropping their void shells removes the trigger.)

## Fix

Authored by **Bob Haimes**: wrap `BRepClass3d::OuterShell(Solid)` in a `try/catch` in `egadsTopo.cpp`. On failure, fall back to the shell with the largest bounding box as the outer shell.

Ported to the ESP 1.29 patch set as a new `egadsTopoOuterShell129.patch`, wired into `download.sh`'s `129` block after the existing FXC-6881 patches (`egadsTopo129.patch`, `egadsIO129.patch`). The patch is generated against the **ESP129 prebuilt tarball source** (CRLF line endings, matching the existing 129 patches) — not the vendored `EngSketchPad/` tree, whose line numbering differs.

## Changes
- `egadsTopoOuterShell129.patch` (new) — Bob's `OuterShell` try/catch + largest-bbox fallback
- `download.sh` — apply the new patch as the third `129` patch; updated the echo line

## Test plan
- ✅ `./download.sh 129` runs end-to-end and exits **0** — all three 129 patches apply cleanly (no failed hunks / rejects)
- ✅ Confirmed the guard lands in the patched `ESP/EngSketchPad/src/EGADS/src/egadsTopo.cpp`
- ✅ Statically verified the fix's identifiers (`i`, `j`, `shape`, `nShell`) are in scope in `EG_traverseBody`, and `Bnd_Box`/`BRepBndLib`/`CASVER`/`math.h` are already available — so it compiles in the 1.29 tree
- ⏳ Full repro against the Scania STEP (GAI tessellator harness) not run here — left to Miles / reviewer

## Refs
- Jira: [FXC-8846](https://flow360.atlassian.net/browse/FXC-8846)
- Slack: Miles ↔ Bob Haimes thread (root cause + fix)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes solid outer-shell classification during EGADS body traversal; wrong fallback shell could mis-classify void topology but avoids hard crashes on bad STEP geometry.
> 
> **Overview**
> Adds **FXC-8846** protection so `EG_loadModel` no longer aborts when OpenCASCADE throws from `BRepClass3d::OuterShell` on solids with invalid void topology (e.g. customer STEP bodies with bad brep-with-voids).
> 
> The change is delivered as a new **`egadsTopoOuterShell129.patch`** on the ESP 1.29 tarball: **`OuterShell`** is wrapped in **`try/catch`**, logs a warning, and on failure picks the outer shell by **largest bounding box** (or the sole shell when `nShell == 1`). **`download.sh`** applies this patch after the existing 129 **`egadsTopo`** / **`egadsIO`** patches and updates the echo line.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7a8ae85499aa7249a9911b224ec9a0a69c225f24. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->