### PR TITLE
download.sh: retry transient MIT fetch failures (fail fast on expected 404)

### DIFF
--- a/download.sh
+++ b/download.sh
@@ -7,19 +7,32 @@ set -x # echo commands
 version=${1:-129}
 tar=ESP${version}-linux-x86_64.tgz
 
-# MIT rotates older releases from PreBuilts/ to archive/
+# A given ESP version lives in exactly ONE of PreBuilts/ or archive/: MIT moves
+# a release from PreBuilts/ to archive/ once it ages out, so a 404 from the
+# other directory is EXPECTED and must not abort the build. Reaching
+# acdl.mit.edu can also fail transiently (connection timeouts, 5xx) -- that is
+# what we retry. curl's --retry covers those transient errors but never a 404,
+# and --connect-timeout keeps a hung endpoint from stalling the job for minutes.
 prebuilts_url=https://acdl.mit.edu/ESP/PreBuilts/${tar}
 archive_url=https://acdl.mit.edu/ESP/archive/${tar}
 
-if curl --head --silent --fail "$prebuilts_url" > /dev/null 2>&1; then
-  curl -O "$prebuilts_url" -o ${tar}
-elif curl --head --silent --fail "$archive_url" > /dev/null 2>&1; then
-  echo "Not found in PreBuilts, downloading from archive"
-  curl -O "$archive_url" -o ${tar}
+mit_curl() {
+  curl --fail --location --connect-timeout 30 \
+       --retry 5 --retry-delay 5 --retry-connrefused "$@"
+}
+
+if mit_curl --silent --head --max-time 120 "$prebuilts_url" > /dev/null; then
+  url=$prebuilts_url
+  echo "Found ESP${version} in PreBuilts"
+elif mit_curl --silent --head --max-time 120 "$archive_url" > /dev/null; then
+  url=$archive_url
+  echo "Not in PreBuilts (expected); found ESP${version} in archive"
 else
-  echo "ERROR: ESP${version} not found in PreBuilts or archive" >&2
+  echo "ERROR: ESP${version} unreachable in PreBuilts or archive after retries" >&2
   exit 1
 fi
+
+mit_curl --silent --show-error --max-time 1800 -o "${tar}" "$url"
 
 rm -rf ESP ESP${version}
 tar xzf ${tar}


### PR DESCRIPTION
## Summary

The ESP **1.29.2** release build [failed](https://github.com/flexcompute/EngineeringSketchPad/actions/runs/27208506070) at `Run download.sh`: both `curl --head` probes to `acdl.mit.edu` **timed out (~134s each)**, so the script hit its not-found branch and exited 1. MIT was actually up — it was a transient runner→MIT connectivity blip (a re-run succeeded immediately).

## Change

Route both the location probe and the download through a `mit_curl()` helper:
- `--retry 5 --retry-delay 5 --retry-connrefused` — ride out transient errors (timeouts, 5xx, refused connections).
- `--connect-timeout 30` — a hung endpoint fails in 30s instead of stalling for minutes.
- **A 404 is not retried** (curl's `--retry` skips it), by design: a given ESP version lives in exactly **one** of `PreBuilts/` or `archive/` (MIT moves releases to `archive/` as they age out), so a 404 from the other directory is **expected** and should fail over immediately rather than burn retries.
- Dropped the redundant `-O … -o` (which logged `Got more output options than URLs`).

## Test plan
- ✅ `bash -n download.sh` clean
- ✅ `./download.sh 129` end-to-end: probe → download → all three 129 patches applied, **exit 0**
- ✅ Expected 404 (`archive/ESP129…`) fails fast, **no retry** (~0s, exit 22)
- ✅ 200 probe (`PreBuilts/ESP129…`) succeeds immediately

Context: surfaced while cutting ESP 1.29.2 (the release carrying the FXC-8846 OuterShell fix, #23).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Build-script-only change to download reliability; no auth, data, or application runtime paths affected.
> 
> **Overview**
> **Hardens MIT ESP tarball fetching** in `download.sh` so CI no longer fails on transient `acdl.mit.edu` timeouts while still failing over quickly when a version is only in `archive/` (expected 404).
> 
> A new `mit_curl()` helper wraps probe and download `curl` calls with `--connect-timeout 30`, `--retry 5`, and related flags for timeouts/5xx/refused connections; **404s are not retried**, so PreBuilts vs archive probing stays immediate. The script picks the winning URL from HEAD checks, downloads once with `-o`, and drops the invalid `-O … -o` combination. Comments and log/error text clarify one-location-per-version semantics and “unreachable after retries” vs hard not-found.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 37d4633cbc0a497d02045387b80cb532e593ad5d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->